### PR TITLE
fix(wsman): authorize uri is always /wsman

### DIFF
--- a/pkg/wsman/client.go
+++ b/pkg/wsman/client.go
@@ -67,7 +67,7 @@ func (c *Client) Post(msg string) (response []byte, err error) {
 
 	if c.username != "" && c.password != "" {
 		if c.useDigest {
-			auth, err := c.challenge.authorize("POST", c.endpoint)
+			auth, err := c.challenge.authorize("POST", "/wsman")
 			if err != nil {
 				return nil, fmt.Errorf("failed digest auth %v", err)
 			}


### PR DESCRIPTION
Previous implementation was using the c.endpoint for initial Authorization header. This always resulted in 401 error and the subsequent Authorization uses only "/wsman".