### PR TITLE
fix: only send Digest challenge when realm is known

### DIFF
--- a/pkg/wsman/client/wsman.go
+++ b/pkg/wsman/client/wsman.go
@@ -83,7 +83,9 @@ func (c *Target) Post(msg string) (response []byte, err error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed digest auth %v", err)
 			}
-			req.Header.Set("Authorization", auth)
+			if c.challenge.Realm != "" {
+				req.Header.Set("Authorization", auth)
+			}
 		} else {
 			req.SetBasicAuth(c.username, c.password)
 		}


### PR DESCRIPTION
Based on testing, AMT (v12) refuses to respond to unknown Digest challenge with blank realm. This patch prevents such challenge to be sent allowing normal Digest challenge flow to continue.