### PR TITLE
fix(amt): timesynchronization response struct

### DIFF
--- a/pkg/amt/timesynchronization/service.go
+++ b/pkg/amt/timesynchronization/service.go
@@ -16,12 +16,13 @@ const AMT_TimeSynchronizationService = "AMT_TimeSynchronizationService"
 
 type (
 	Response struct {
-		XMLName xml.Name `xml:"Envelope"`
-		Header  message.Header
-		Body
+		XMLName xml.Name       `xml:"Envelope"`
+		Header  message.Header `xml:"Header"`
+		Body    Body           `xml:"Body"`
 	}
 	Body struct {
-		GetLowAccuracyTimeSynch_OUTPUT
+		XMLName                         xml.Name `xml:"Body"`
+		GetLowAccuracyTimeSynch_OUTPUT  GetLowAccuracyTimeSynch_OUTPUT
 		SetHighAccuracyTimeSynch_OUTPUT message.ReturnValue
 	}
 	GetLowAccuracyTimeSynch_OUTPUT struct {

--- a/pkg/amt/timesynchronization/service_test.go
+++ b/pkg/amt/timesynchronization/service_test.go
@@ -6,6 +6,8 @@
 package timesynchronization
 
 import (
+	"encoding/xml"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,4 +52,81 @@ func TestAMT_TimeSynchronizationService(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("should parse GetLowAccuracyTimeSynch response", func(t *testing.T) {
+		// change the return value from 0 as that is default and doesn't
+		// prove that xml was parsed correctly
+		xmlWithErr := strings.Replace(getLowAccuracyTimeSynchXMLResponse,
+			`<g:ReturnValue>0</g:ReturnValue>`,
+			`<g:ReturnValue>1</g:ReturnValue>`, 1)
+		var rsp Response
+		err := xml.Unmarshal([]byte(xmlWithErr), &rsp)
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1704394160), rsp.Body.GetLowAccuracyTimeSynch_OUTPUT.Ta0)
+		assert.Equal(t, 1, rsp.Body.GetLowAccuracyTimeSynch_OUTPUT.ReturnValue)
+	})
+
+	t.Run("should parse SetHighAccuracyTimeSynch response", func(t *testing.T) {
+		// change the return value from 0 as that is default and doesn't
+		// prove that xml was parsed correctly
+		xmlWithErr := strings.Replace(setHighAccuracyTimeSynchXMLResponse,
+			`<g:ReturnValue>0</g:ReturnValue>`,
+			`<g:ReturnValue>1</g:ReturnValue>`, 1)
+		var rsp Response
+		err := xml.Unmarshal([]byte(xmlWithErr), &rsp)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, rsp.Body.SetHighAccuracyTimeSynch_OUTPUT.ReturnValue)
+	})
 }
+
+const getLowAccuracyTimeSynchXMLResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+            xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+            xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+            xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>0</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">
+            http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService/GetLowAccuracyTimeSynchResponse
+        </b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000011E1F</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:GetLowAccuracyTimeSynch_OUTPUT>
+            <g:Ta0>1704394160</g:Ta0>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:GetLowAccuracyTimeSynch_OUTPUT>
+    </a:Body>
+</a:Envelope>`
+
+const setHighAccuracyTimeSynchXMLResponse = `
+<?xml version="1.0" encoding="UTF-8"?>
+<a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust"
+            xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+            xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+            xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <a:Header>
+        <b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>
+        <b:RelatesTo>9</b:RelatesTo>
+        <b:Action a:mustUnderstand="true">
+            http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService/SetHighAccuracyTimeSynchResponse
+        </b:Action>
+        <b:MessageID>uuid:00000000-8086-8086-8086-000000000061</b:MessageID>
+        <c:ResourceURI>http://intel.com/wbem/wscim/1/amt-schema/1/AMT_TimeSynchronizationService</c:ResourceURI>
+    </a:Header>
+    <a:Body>
+        <g:SetHighAccuracyTimeSynch_OUTPUT>
+            <g:ReturnValue>0</g:ReturnValue>
+        </g:SetHighAccuracyTimeSynch_OUTPUT>
+    </a:Body>
+</a:Envelope>
+`


### PR DESCRIPTION
added unit tests for correctly unmarshalling xml to responses 