### PR TITLE
fix: Digest hash URI for wsman must be "/wsman", not full url

### DIFF
--- a/pkg/wsman/client/wsman.go
+++ b/pkg/wsman/client/wsman.go
@@ -86,7 +86,7 @@ func (c *Target) Post(msg string) (response []byte, err error) {
 	if c.username != "" && c.password != "" {
 		if c.useDigest {
 
-			auth, err := c.challenge.authorize("POST", c.endpoint)
+			auth, err := c.challenge.authorize("POST", "/wsman")
 			if err != nil {
 				return nil, fmt.Errorf("failed digest auth %v", err)
 			}


### PR DESCRIPTION
This small change fixes #240 