### PR TITLE
fix: correcting tls, tls1only and mode parameters for WebSocket relay

### DIFF
--- a/pkg/wsman/client/relay.go
+++ b/pkg/wsman/client/relay.go
@@ -32,6 +32,7 @@ type WsTransport struct {
 	tls       bool
 	tls1only  bool
 	token     string
+	mode      string
 	conn      *websocket.Conn
 	tlsconfig *tls.Config
 	buf_mutex sync.Mutex
@@ -39,7 +40,7 @@ type WsTransport struct {
 }
 
 // NewTransport creates a new Websocket RoundTripper.
-func NewWsTransport(wsurl string, protocol int, host, username, password string, port int, tls, tls1only bool, token string, tlsconfig *tls.Config) *WsTransport {
+func NewWsTransport(wsurl string, protocol int, host, username, password string, port int, tls, tls1only bool, token string, mode string, tlsconfig *tls.Config) *WsTransport {
 	t := &WsTransport{
 		wsurl:     wsurl,
 		protocol:  protocol,
@@ -50,6 +51,7 @@ func NewWsTransport(wsurl string, protocol int, host, username, password string,
 		tls:       tls,
 		tls1only:  tls1only,
 		token:     token,
+		mode:      mode,
 		tlsconfig: tlsconfig,
 		buf_mutex: sync.Mutex{},
 	}
@@ -76,8 +78,15 @@ func (t *WsTransport) buildUrl() string {
 	q.Set("user", t.username)
 	q.Set("pass", t.password)
 	q.Set("port", strconv.Itoa(t.port))
-	q.Set("tls", strconv.FormatBool(t.tls))
-	q.Set("tls1only", strconv.FormatBool(t.tls1only))
+	q.Set("tls", "0")
+	if t.tls {
+		q.Set("tls", "1")
+	}
+	q.Set("tls1only", "0")
+	if t.tls1only {
+		q.Set("tls1only", "1")
+	}
+	q.Set("mode", t.mode)
 	// Set query string to URL
 	u.RawQuery = q.Encode()
 	return u.String()

--- a/pkg/wsman/client/relay_test.go
+++ b/pkg/wsman/client/relay_test.go
@@ -18,7 +18,7 @@ import (
 var tlsconfig = &tls.Config{}
 
 func TestNewWsTransport(t *testing.T) {
-	trans := NewWsTransport("wss://localhost/mps/ws/relay/webrelay.ashx", 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport("wss://localhost/mps/ws/relay/webrelay.ashx", 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -26,7 +26,7 @@ func TestNewWsTransport(t *testing.T) {
 
 func TestNewWsTransportBuildUrl(t *testing.T) {
 	baseurl := "wss://localhost/mps/ws/relay/webrelay.ashx"
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -35,13 +35,17 @@ func TestNewWsTransportBuildUrl(t *testing.T) {
 		t.Error("Failed to build url")
 	}
 	// second path
-	trans = NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, true, true, "token", tlsconfig)
+	trans = NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, true, true, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
 	url = trans.buildUrl()
 	if url == "" {
 		t.Error("Failed to build url")
+	}
+	//check if it has tls=1 and tls1only=1
+	if !strings.Contains(url, "tls=1") || !strings.Contains(url, "tls1only=1") {
+		t.Error("tls or tls1only invalid")
 	}
 }
 
@@ -120,7 +124,7 @@ func TestNewWsTransportRoundtripBadParam(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http")
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -141,7 +145,7 @@ func TestNewWsTransportRoundtripBadUrl(t *testing.T) {
 	baseurl := "ws://localhot/"
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -162,7 +166,7 @@ func TestNewWsTransportRoundtripGet(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http")
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -186,7 +190,7 @@ func TestNewWsTransportRoundtripPost(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http")
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -210,7 +214,7 @@ func TestNewWsTransportFailedConnection(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http") + "/simulate_fail"
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -231,7 +235,7 @@ func TestNewWsTransportCloseConnection(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http") + "/simulate_close"
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}
@@ -252,7 +256,7 @@ func TestNewWsTransportDelay(t *testing.T) {
 	baseurl := "ws" + strings.TrimPrefix(s.URL, "http") + "/simulate_delay"
 
 	// Connect to the server
-	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", tlsconfig)
+	trans := NewWsTransport(baseurl, 1, "9b3ee6a0-c1dc-5546-f7f3-54b2039edfb9", "user", "pass", 16992, false, false, "token", "wsman", tlsconfig)
 	if trans == nil {
 		t.Error("NewWSTransporter constructor fails")
 	}


### PR DESCRIPTION
- ensure tls and tls1only parameters are integer and not boolean string
- add mode parameter as required by MPS latest changes related to IDE-R