### PR TITLE
fix: adds wireless profile name to v2 config for use as ElementName w…

### DIFF
--- a/pkg/config/v2.go
+++ b/pkg/config/v2.go
@@ -48,6 +48,7 @@ type Wireless struct {
 }
 
 type WirelessProfile struct {
+	ProfileName          string     `yaml:"profileName"`
 	SSID                 string     `yaml:"ssid"`
 	Password             string     `yaml:"password"`
 	AuthenticationMethod string     `yaml:"authenticationMethod"`


### PR DESCRIPTION
…/ AMT